### PR TITLE
[Fix] Export `LockGuard`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ pub mod std;
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
-pub use lock_info::{lock_snapshots, GuardInfo, GuardKind, Location, LockInfo, LockKind};
+pub use lock_info::{
+    lock_snapshots, GuardInfo, GuardKind, Location, LockGuard, LockInfo, LockKind,
+};
 
 #[cfg(feature = "test")]
 pub use lock_info::clear_lock_infos;

--- a/src/lock_info.rs
+++ b/src/lock_info.rs
@@ -123,7 +123,7 @@ impl fmt::Display for LockInfo {
         write!(f, "{} ({:?}):", self.location, self.kind)?;
 
         for guard in self.known_guards.values() {
-            write!(f, "\n- {}", guard)?;
+            write!(f, "\n- {guard}")?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR changes locktick to export its `LockGuard` struct. This is useful when using locktick locks in function signatures.

It also exports parking-lot specific lock guards for the same reason.