### PR TITLE
[Feature] Track waiting tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "locktick"
 version = "0.4.0"
 edition = "2021"
+rust-version = "1.80"
 authors = ["ljedrz <ljedrz@gmail.com>"]
 description = "Automated lock accounting & profiling"
 license = "CC0-1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod std;
 pub mod tokio;
 
 pub use lock_info::{
-    lock_snapshots, GuardInfo, GuardKind, Location, LockGuard, LockInfo, LockKind,
+    lock_snapshots, GuardInfo, GuardKind, Location, LockGuard, LockInfo, LockKind, WaitGuard,
 };
 
 #[cfg(feature = "test")]

--- a/src/std.rs
+++ b/src/std.rs
@@ -6,7 +6,9 @@ use std::{
 #[cfg(feature = "tracing")]
 use tracing::trace;
 
-use crate::lock_info::{call_location, GuardKind, Location, LockGuard, LockInfo, LockKind, WaitGuard};
+use crate::lock_info::{
+    call_location, GuardKind, Location, LockGuard, LockInfo, LockKind, WaitGuard,
+};
 
 #[derive(Debug)]
 pub struct Mutex<T> {


### PR DESCRIPTION
This PR adds a mechanism to keep track of the threads/tasks waiting for a lock. This is very helpful to debug deadlocks, because you cannot only see which locks are held, but also if tasks cannot make progress because they are waiting for a lock to become available.

The implementation provides a fast path, using `try_lock` or similar, that does not introduce any overhead in the absence of lock contention.
If the initial attempt to grab a lock fails, it will create `WaitGuard` that acts similar to the existing `LockGuard` struct. Once a task is done waiting for a lock, the `WaitGuard` is converted into `LockGuard`.